### PR TITLE
Support instances where bookmarks have no created date

### DIFF
--- a/backend/readwise_test.go
+++ b/backend/readwise_test.go
@@ -92,6 +92,36 @@ func TestBuildPayload_TitleFallbackFailure(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestBuildPayload_NoHighlightDateCreated(t *testing.T) {
+	highlights := []Highlight{{
+		Text:          "Hello World",
+		SourceURL:     "\t",
+		SourceType:    SourceType,
+		Category:      SourceCategory,
+		Note:          "Making a note here",
+		HighlightedAt: "2006-01-02T15:04:05+00:00",
+	}}
+	expected := Response{Highlights: highlights}
+	contentIndex := map[string]Content{"\t": {ContentID: "\t"}}
+	bookmarks := []Bookmark{
+		{VolumeID: "\t", Text: "Hello World", DateCreated: "", Annotation: "Making a note here", DateModified: "2006-01-02T15:04:05Z"},
+	}
+	var actual, _ = BuildPayload(bookmarks, contentIndex)
+	assert.Equal(t, expected, actual)
+}
+
+func TestBuildPayload_NoHighlightDateAtAll(t *testing.T) {
+	contentIndex := map[string]Content{"\t": {ContentID: "\t"}}
+	bookmarks := []Bookmark{
+		{VolumeID: "abc123", Text: "Hello World", Annotation: "Making a note here"},
+	}
+	var actual, _ = BuildPayload(bookmarks, contentIndex)
+	assert.Equal(t, actual.Highlights[0].SourceURL, bookmarks[0].VolumeID)
+	assert.Equal(t, actual.Highlights[0].Text, bookmarks[0].Text)
+	assert.Equal(t, actual.Highlights[0].Note, bookmarks[0].Annotation)
+	assert.NotEmpty(t, actual.Highlights[0].HighlightedAt)
+}
+
 func TestBuildPayload_SkipMalformedBookmarks(t *testing.T) {
 	var expected Response
 	contentIndex := map[string]Content{"mnt://kobo/blah/Good Book - An Author.epub": {ContentID: "mnt://kobo/blah/Good Book - An Author.epub"}}


### PR DESCRIPTION
Closes: #56 
Closes: #47

For reasons that I don't quite understand, it is possible for highlights to have an empty `DateCreated` field which causes October to fail to parse those highlights.

This PR checks the contents of that field and if it's empty, it attempts to use `DateModified` which, as far as I understand, is the date that a highlight is last edited and should roughly match `DateCreated`.

If `DateModified` doesn't exist, it'll do a further fallback and just use today's date.

Should that somehow fail, it'll throw up the error that it was before but that shouldn't really be possible.